### PR TITLE
Make index directory if it does not exist.

### DIFF
--- a/src/hera_build
+++ b/src/hera_build
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import sys
+import os
 import argparse
 import subprocess
 import struct
 
 # Global variant
-# GENOME: { 
-#	chr_name: { 
+# GENOME: {
+#	chr_name: {
 #		seq: string,
 #		order: integer,
 #		gene_id: {
@@ -54,7 +55,7 @@ def load_genome(args):
 			else:
 				seq += line[:-1]
 		GENOME[name] = {"seq" : seq, "order" : order - 1}
-		
+
 		# 1 integer for name length
 		# 1 integer for sequence length
 		total += len(name) + 2*INTEGER*order
@@ -92,7 +93,7 @@ def extract_transcriptome(args):
 					if k[0] == "gene_id" or k[0] == "transcript_id":
 						transcript_inf[k[0]] = k[1]
 				try:
-					GENOME[line[0]][transcript_inf["gene_id"]][transcript_inf["transcript_id"]] = [] 
+					GENOME[line[0]][transcript_inf["gene_id"]][transcript_inf["transcript_id"]] = []
 				except:
 					continue
 			elif line[2] == "exon":
@@ -112,13 +113,12 @@ def extract_transcriptome(args):
 def write_index(total_byte, gene_info):
 	print ("Extract transcript sequence")
 	outdir = args.outdir
-	if outdir[-1] != '/':
-		outdir += '/'
-
+        if not os.path.exists(outdir):
+                os.makedirs(outdir)
 	# Store sequence of all transcript
-	f = open(outdir + "transcripts.fasta", "w")
+	f = open(os.path.join(outdir, "transcripts.fasta"), "w")
 	# Store index for query
-	fi = open(outdir + "reference.inf", "wb")
+	fi = open(os.path.join(outdir, "reference.inf"), "wb")
 
 	# BAM header [name length, name, sequence length]
 	maxNameLen = 0
@@ -182,7 +182,7 @@ def write_index(total_byte, gene_info):
 			if gene == "seq" or gene == "order":
 				continue
 			for transcript in GENOME[chr][gene]:
-				if transcript == "inf":                                                     
+				if transcript == "inf":
 					continue
 				fi.write(struct.pack("I", GENOME[chr][gene]["inf"]))
 
@@ -199,4 +199,4 @@ path = sys.argv[0].replace("hera_build", "hera")
 full = args.full_index
 if str(full) == "None":
 	full = "0"
-subprocess.call([path , "index", args.outdir + "transcripts.fasta", args.fasta, args.outdir + "index", full])
+subprocess.call([path , "index", os.path.join(args.outdir, "transcripts.fasta"), args.fasta, os.path.join(args.outdir, "index"), full])


### PR DESCRIPTION
Heya, this creates the index output directory if it doesn't exist, and swaps the script over to use a platform independent method for constructing paths with os.path.join.